### PR TITLE
Networking Without DataOperation

### DIFF
--- a/Sources/ImageFetcher/Extensions/URLSession+Utils.swift
+++ b/Sources/ImageFetcher/Extensions/URLSession+Utils.swift
@@ -1,0 +1,70 @@
+//
+//  URLSession+Utils.swift
+//  Mobelux
+//
+//  MIT License
+//
+//  Copyright (c) 2022 Mobelux LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+public extension URLSession {
+    final class WrappedTask {
+        public var task: URLSessionDataTask?
+    }
+
+    enum DataError: LocalizedError {
+        case unknown
+        case custom(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .unknown: return NSLocalizedString("Generic.unknownError", comment: "")
+            case .custom(let message): return message
+            }
+        }
+    }
+
+    @available(iOS, deprecated: 15.0)
+    @available(macOS, deprecated: 12.0)
+    @available(tvOS, deprecated: 15.0)
+    @available(watchOS, deprecated: 8.0)
+    func legacyData(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let wrappedTask = WrappedTask()
+        return try await withTaskCancellationHandler {
+            wrappedTask.task?.cancel()
+        } operation: {
+            try await withUnsafeThrowingContinuation { continuation in
+                wrappedTask.task = dataTask(with: request) { data, response, error in
+                    if let error = error {
+                        continuation.resume(with: .failure(error))
+                    } else if let data = data, let response = response {
+                        continuation.resume(with: .success((data, response)))
+                    } else {
+                        continuation.resume(with: .failure(DataError.unknown))
+                    }
+                }
+                wrappedTask.task?.resume()
+            }
+        }
+    }
+}

--- a/Sources/ImageFetcher/Extensions/URLSession+Utils.swift
+++ b/Sources/ImageFetcher/Extensions/URLSession+Utils.swift
@@ -44,10 +44,13 @@ public extension URLSession {
         }
     }
 
-    @available(iOS, deprecated: 15.0)
-    @available(macOS, deprecated: 12.0)
-    @available(tvOS, deprecated: 15.0)
-    @available(watchOS, deprecated: 8.0)
+    /// Downloads the contents of a URL based on the specified URL request and delivers the data asynchronously.
+    /// - Parameter request: A URL request object that provides request-specific information such as the URL, cache policy, request type, and body data or body stream.
+    /// - Returns: An asynchronously-delivered tuple that contains the URL contents as a `Data` instance, and a `URLResponse`.
+    @available(iOS, deprecated: 15.0, message: "Use `URLSession.data(for:delegate:)` instead.")
+    @available(macOS, deprecated: 12.0, message: "Use `URLSession.data(for:delegate:)` instead.")
+    @available(tvOS, deprecated: 15.0, message: "Use `URLSession.data(for:delegate:)` instead.")
+    @available(watchOS, deprecated: 8.0, message: "Use `URLSession.data(for:delegate:)` instead.")
     func legacyData(for request: URLRequest) async throws -> (Data, URLResponse) {
         let wrappedTask = WrappedTask()
         return try await withTaskCancellationHandler {

--- a/Sources/ImageFetcher/Extensions/URLSessionConfiguration+cacheless.swift
+++ b/Sources/ImageFetcher/Extensions/URLSessionConfiguration+cacheless.swift
@@ -28,6 +28,7 @@
 import Foundation
 
 public extension URLSessionConfiguration {
+    /// A session configuration object with caching disabled.
     static let cacheless: URLSessionConfiguration = {
         let configuration = URLSessionConfiguration.default
         // Disable caching since we are going to use our own caches.

--- a/Sources/ImageFetcher/Extensions/URLSessionConfiguration+cacheless.swift
+++ b/Sources/ImageFetcher/Extensions/URLSessionConfiguration+cacheless.swift
@@ -1,0 +1,38 @@
+//
+//  URLSessionConfiguration+cacheless.swift
+//  Mobelux
+//
+//  MIT License
+//
+//  Copyright (c) 2022 Mobelux LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+public extension URLSessionConfiguration {
+    static let cacheless: URLSessionConfiguration = {
+        let configuration = URLSessionConfiguration.default
+        // Disable caching since we are going to use our own caches.
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        return configuration
+    }()
+}

--- a/Sources/ImageFetcher/Networking.swift
+++ b/Sources/ImageFetcher/Networking.swift
@@ -27,11 +27,15 @@
 
 import Foundation
 
+/// A simple wrapper for a closure performing an async network request.
 public struct Networking {
+    /// Downloads the contents of a URL based on the specified URL request and delivers the data asynchronously.
     public let load: (URLRequest) async throws -> (Data, URLResponse)
 }
 
 public extension Networking {
+    /// Creates a network request wrapper with the specified session configuration.
+    /// - Parameter configuration: A configuration object that specifies certain behaviors, such as caching policies, timeouts, proxies, pipelining, TLS versions to support, cookie policies, credential storage, and so on.
     init(_ configuration: URLSessionConfiguration = .cacheless) {
         let session = URLSession(configuration: configuration)
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {

--- a/Sources/ImageFetcher/Networking.swift
+++ b/Sources/ImageFetcher/Networking.swift
@@ -1,0 +1,47 @@
+//
+//  Networking.swift
+//  Mobelux
+//
+//  MIT License
+//
+//  Copyright (c) 2022 Mobelux LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+public struct Networking {
+    public let load: (URLRequest) async throws -> (Data, URLResponse)
+}
+
+public extension Networking {
+    init(_ configuration: URLSessionConfiguration = .cacheless) {
+        let session = URLSession(configuration: configuration)
+        if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+            self.load = { request in
+                try await session.data(for: request)
+            }
+        } else {
+            self.load = { request in
+                try await session.legacyData(for: request)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Defines a basic wrapper for an async-based network request method as an alternative to `DataOperation`.

The basic idea:

```swift
public actor ImageFetcher {
    internal var cache: Cache
    internal let networking: Networking

    // ...

    public init(_ cache: Cache, networking: Networking = .init()) {
        self.cache = cache
        self.networking = networking
    }

    // ...

    public func load(_ imageConfiguration: ImageConfiguration) async throws -> ResultType<Image> {
        // ...
        let request = URLRequest(url: imageConfiguration.url)
        let data = try await networking.load(request).0
        // ...
    }
}
```