### PR TITLE
Fix Crash + Performance Tests

### DIFF
--- a/Sources/ImageFetcher/ImageFetcher.swift
+++ b/Sources/ImageFetcher/ImageFetcher.swift
@@ -44,12 +44,17 @@ import DiskCache
 
 public final class ImageFetcher: ImageFetching {
     internal var cache: Cache
+    private let session: Session
     private var queue: Queue
     private var tasks: Set<ImageFetcherTask> = []
     private var workerQueue = DispatchQueue(label: "com.mobelux.image-fetcher")
 
-    public init(_ cache: Cache, queue: Queue = OperationQueue(), maxConcurrent: Int = 2) {
+    public init(_ cache: Cache,
+                session: Session = URLSession(configuration: .default),
+                queue: Queue = OperationQueue(),
+                maxConcurrent: Int = 2) {
         self.cache = cache
+        self.session = session
         self.queue = queue
 
         self.queue.maxConcurrentOperationCount = maxConcurrent
@@ -100,7 +105,7 @@ public extension ImageFetcher {
                             configuration: imageConfiguration,
                             result: .success(.cached(image))))
                 } else {
-                    let operation = DataOperation(request: URLRequest(url: imageConfiguration.url))
+                    let operation = DataOperation(request: URLRequest(url: imageConfiguration.url), session: session)
                     operation.name = imageConfiguration.key
 
                     let task = ImageFetcherTask(configuration: imageConfiguration, operation: operation)

--- a/Sources/ImageFetcher/ImageFetcher.swift
+++ b/Sources/ImageFetcher/ImageFetcher.swift
@@ -300,7 +300,18 @@ private extension ImageFetcher {
 
             // call the handle with an image result
             task.result = imageResult
+
+            // remove fetcher task from tasks
+            sself.workerQueue.sync {
+                _ = sself.tasks.remove(task)
+            }
         }
     }
 }
 
+// MARK: - Internal Test Members
+internal extension ImageFetcher {
+    var taskCount: Int {
+        tasks.count
+    }
+}

--- a/Sources/ImageFetcher/ImageFetcher.swift
+++ b/Sources/ImageFetcher/ImageFetcher.swift
@@ -46,7 +46,7 @@ public final class ImageFetcher: ImageFetching {
     internal var cache: Cache
     private var queue: Queue
     private var tasks: Set<ImageFetcherTask> = []
-    private var workerQueue = DispatchQueue.global()
+    private var workerQueue = DispatchQueue(label: "com.mobelux.image-fetcher")
 
     public init(_ cache: Cache, queue: Queue = OperationQueue(), maxConcurrent: Int = 2) {
         self.cache = cache

--- a/Tests/ImageFetcherTests/Helpers.swift
+++ b/Tests/ImageFetcherTests/Helpers.swift
@@ -1,0 +1,94 @@
+import Foundation
+import ImageFetcher
+import XCTest
+
+#if os(macOS)
+import AppKit
+
+public typealias Color = NSColor
+
+extension Color {
+    public func image(_ size: CGSize = CGSize(width: 1, height: 1)) -> Image {
+        let image = Image(size: size)
+        image.lockFocus()
+        drawSwatch(in: NSRect(origin: .zero, size: size))
+        image.unlockFocus()
+        return image
+    }
+}
+#else
+import UIKit
+
+public typealias Color = UIColor
+
+extension Color {
+    public func image(_ size: CGSize = CGSize(width: 1, height: 1)) -> UIImage {
+        UIGraphicsImageRenderer(size: size).image { rendererContext in
+            self.setFill()
+            rendererContext.fill(CGRect(origin: .zero, size: size))
+        }
+    }
+}
+#endif
+
+extension Color {
+    public static func random() -> Color {
+        // Generate between 0 to 1
+        let red = CGFloat(drand48())
+        let green = CGFloat(drand48())
+        let blue = CGFloat(drand48())
+
+        return Color(red: red, green: green, blue: blue, alpha: 1.0)
+    }
+}
+
+enum Mock {
+    static func makeResponse(url: URL, statusCode: Int = 200, headerFields: [String: String]? = nil) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: headerFields)!
+    }
+}
+
+final class URLProtocolMock: URLProtocol {
+    static var responseProvider: (URL) -> Result<(Data, HTTPURLResponse), ImageError> = { url in
+        .success((Data(), Mock.makeResponse(url: url)))
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let client = client else { return }
+
+        do {
+            let url = try XCTUnwrap(request.url)
+            let result = Self.responseProvider(url)
+
+            switch result {
+            case let .success((data, response)):
+                client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client.urlProtocol(self, didLoad: data)
+            case .failure(let error):
+                client.urlProtocol(self, didFailWithError: error)
+            }
+        } catch {
+            client.urlProtocol(self, didFailWithError: error)
+        }
+
+        client.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() { }
+}
+
+extension URLSessionConfiguration {
+    static var mock: URLSessionConfiguration {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [URLProtocolMock.self]
+        return config
+    }
+}

--- a/Tests/ImageFetcherTests/Helpers.swift
+++ b/Tests/ImageFetcherTests/Helpers.swift
@@ -43,6 +43,8 @@ extension Color {
 }
 
 enum Mock {
+    static var baseURL = URL(string: "https://example.com")!
+
     static func makeResponse(url: URL, statusCode: Int = 200, headerFields: [String: String]? = nil) -> HTTPURLResponse {
         HTTPURLResponse(
             url: url,

--- a/Tests/ImageFetcherTests/Helpers.swift
+++ b/Tests/ImageFetcherTests/Helpers.swift
@@ -52,9 +52,11 @@ enum Mock {
     }
 }
 
-final class URLProtocolMock: URLProtocol {
-    static var responseProvider: (URL) -> Result<(Data, HTTPURLResponse), ImageError> = { url in
-        .success((Data(), Mock.makeResponse(url: url)))
+final class MockURLProtocol: URLProtocol {
+    static var responseQueue: DispatchQueue = .global()
+    static var responseDelay: TimeInterval? = nil
+    static var responseProvider: (URL) throws -> (Data, HTTPURLResponse) = { url in
+        (Data(), Mock.makeResponse(url: url))
     }
 
     override class func canInit(with request: URLRequest) -> Bool { true }
@@ -62,33 +64,36 @@ final class URLProtocolMock: URLProtocol {
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
-        guard let client = client else { return }
-
-        do {
-            let url = try XCTUnwrap(request.url)
-            let result = Self.responseProvider(url)
-
-            switch result {
-            case let .success((data, response)):
-                client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-                client.urlProtocol(self, didLoad: data)
-            case .failure(let error):
-                client.urlProtocol(self, didFailWithError: error)
+        if let delay = Self.responseDelay {
+            guard client != nil else { return }
+            Self.responseQueue.asyncAfter(deadline: .now() + delay) {
+                self.respond()
             }
-        } catch {
-            client.urlProtocol(self, didFailWithError: error)
+        } else {
+            respond()
         }
-
-        client.urlProtocolDidFinishLoading(self)
     }
 
     override func stopLoading() { }
+
+    private func respond() {
+        guard let client = client else { return }
+        do {
+            let url = try XCTUnwrap(request.url)
+            let response = try Self.responseProvider(url)
+            client.urlProtocol(self, didReceive: response.1, cacheStoragePolicy: .notAllowed)
+            client.urlProtocol(self, didLoad: response.0)
+        } catch {
+            client.urlProtocol(self, didFailWithError: error)
+        }
+        client.urlProtocolDidFinishLoading(self)
+    }
 }
 
 extension URLSessionConfiguration {
     static var mock: URLSessionConfiguration {
         let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [URLProtocolMock.self]
+        config.protocolClasses = [MockURLProtocol.self]
         return config
     }
 }

--- a/Tests/ImageFetcherTests/ImageFetcherTests.swift
+++ b/Tests/ImageFetcherTests/ImageFetcherTests.swift
@@ -1,4 +1,42 @@
 import XCTest
 @testable import ImageFetcher
 
-final class ImageFetcherTests: XCTestCase {}
+final class ImageFetcherTests: XCTestCase {
+    static var cache: DiskCache!
+
+    override class func setUp() {
+        super.setUp()
+        do {
+            cache = try DiskCache(storageType: .temporary(nil))
+        } catch {
+            fatalError()
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        do {
+            try Self.cache.syncDeleteAll()
+        } catch {
+            fatalError()
+        }
+    }
+
+    func testCompletedTaskRemoval() throws {
+        let session = URLSession(configuration: .mock)
+        MockURLProtocol.responseProvider = { url in
+            (Data(), Mock.makeResponse(url: url))
+        }
+        let fetcher = ImageFetcher(Self.cache, session: session)
+
+        let exp = expectation(description: "Finished")
+        fetcher.load(Mock.baseURL) { _ in
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+
+        let expected = 0
+        let actual = fetcher.taskCount
+        XCTAssertEqual(expected, actual)
+    }
+}

--- a/Tests/ImageFetcherTests/PerformanceTests.swift
+++ b/Tests/ImageFetcherTests/PerformanceTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import ImageFetcher
 
-final class ImageFetcherPerformanceTests: XCTestCase {
+final class PerformanceTests: XCTestCase {
     enum Constants {
         static let iterationCount = 5_000
         static let imageSide: Int = 250

--- a/Tests/ImageFetcherTests/PerformanceTests.swift
+++ b/Tests/ImageFetcherTests/PerformanceTests.swift
@@ -4,8 +4,8 @@ import XCTest
 final class PerformanceTests: XCTestCase {
     enum Constants {
         static let baseURLString = "https://example.com"
-        static let iterationCount = 1_000
-        static let batchCount = 10
+        static let iterationCount = 500
+        static let batchCount = 5
         static let requestCount = 10
         static let imageSide: Int = 250
         static let maxConcurrent: Int = 2
@@ -69,7 +69,7 @@ final class PerformanceTests: XCTestCase {
             do {
                 try Self.cache.syncDeleteAll()
             } catch {
-                XCTFail()
+                XCTFail("DiskCacke.syncDeleteAll() threw error")
             }
             print("Done")
         }
@@ -108,7 +108,7 @@ final class PerformanceTests: XCTestCase {
             do {
                 try Self.cache.syncDeleteAll()
             } catch {
-                XCTFail()
+                XCTFail("DiskCacke.syncDeleteAll() threw error")
             }
             print("Done")
         }
@@ -145,7 +145,7 @@ final class PerformanceTests: XCTestCase {
             do {
                 try Self.cache.syncDeleteAll()
             } catch {
-                XCTFail()
+                XCTFail("DiskCacke.syncDeleteAll() threw error")
             }
             print("Done")
         }
@@ -186,7 +186,7 @@ final class PerformanceTests: XCTestCase {
             do {
                 try Self.cache.syncDeleteAll()
             } catch {
-                XCTFail()
+                XCTFail("DiskCacke.syncDeleteAll() threw error")
             }
             print("Done")
         }

--- a/Tests/ImageFetcherTests/PerformanceTests.swift
+++ b/Tests/ImageFetcherTests/PerformanceTests.swift
@@ -3,9 +3,12 @@ import XCTest
 
 final class PerformanceTests: XCTestCase {
     enum Constants {
-        static let iterationCount = 5_000
-        static let imageSide: Int = 250
         static let baseURLString = "https://example.com"
+        static let iterationCount = 1_000
+        static let batchCount = 10
+        static let requestCount = 10
+        static let imageSide: Int = 250
+        static let maxConcurrent: Int = 2
         static var imageSize: CGSize {
             .init(width: Self.imageSide, height: Self.imageSide)
         }
@@ -25,6 +28,7 @@ final class PerformanceTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         do {
+            MockURLProtocol.responseDelay = nil
             try Self.cache.syncDeleteAll()
         } catch {
             fatalError()
@@ -47,7 +51,7 @@ final class PerformanceTests: XCTestCase {
         }
 
         measure {
-            let fetcher = ImageFetcher(Self.cache, session: session)
+            let fetcher = ImageFetcher(Self.cache, session: session, maxConcurrent: Constants.maxConcurrent)
 
             var responseCount = 0
             let exp = expectation(description: "Finished")
@@ -71,6 +75,45 @@ final class PerformanceTests: XCTestCase {
         }
     }
 
+    func testSyncPerformanceWithBatches() throws {
+        let session = URLSession(configuration: .mock)
+        MockURLProtocol.responseDelay = 0.3
+        MockURLProtocol.responseProvider = { url in
+            (Color.random().image(Constants.imageSize).pngData()!, Mock.makeResponse(url: url))
+        }
+
+        measure {
+            let fetcher = ImageFetcher(Self.cache, session: session, maxConcurrent: Constants.maxConcurrent)
+
+            let exp = expectation(description: "Finished")
+            for iteration in 0 ... Constants.batchCount {
+                var responseCount = 0
+                let innerExp = expectation(description: "Finished Iteration Requests")
+                for request in 0 ..< Constants.requestCount {
+                    fetcher.load(Self.makeURL(iteration * Constants.requestCount + request)) { _ in
+                        responseCount += 1
+                        if responseCount == Constants.requestCount {
+                            innerExp.fulfill()
+                        }
+                    }
+                }
+
+                wait(for: [innerExp], timeout: 5.0)
+                if iteration == Constants.batchCount {
+                    exp.fulfill()
+                }
+            }
+
+            wait(for: [exp], timeout: 15.0)
+            do {
+                try Self.cache.syncDeleteAll()
+            } catch {
+                XCTFail()
+            }
+            print("Done")
+        }
+    }
+
     func testAsyncPerformance() async throws {
         let session = URLSession(configuration: .mock)
         MockURLProtocol.responseProvider = { url in
@@ -78,23 +121,65 @@ final class PerformanceTests: XCTestCase {
         }
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: true) {
-            let fetcher = ImageFetcher(Self.cache, session: session)
+            let fetcher = ImageFetcher(Self.cache, session: session, maxConcurrent: Constants.maxConcurrent)
 
             let exp = expectation(description: "Finished")
             Task {
-                await withThrowingTaskGroup(of: ImageResult.self) { group in
+                try await withThrowingTaskGroup(of: ImageResult.self) { group in
                     for iteration in 0 ..< Constants.iterationCount {
                         group.addTask {
                             async let image = fetcher.load(Self.makeURL(iteration))
                             return await image
                         }
                     }
+                    try await group.waitForAll()
                 }
 
                 await MainActor.run {
                     stopMeasuring()
                 }
                 exp.fulfill()
+            }
+
+            wait(for: [exp], timeout: 20.0)
+            do {
+                try Self.cache.syncDeleteAll()
+            } catch {
+                XCTFail()
+            }
+            print("Done")
+        }
+    }
+
+    func testAsyncPerformanceForBatches() async throws {
+        let session = URLSession(configuration: .mock)
+        MockURLProtocol.responseDelay = 0.3
+        MockURLProtocol.responseProvider = { url in
+            (Color.random().image(Constants.imageSize).pngData()!, Mock.makeResponse(url: url))
+        }
+
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: true) {
+            let fetcher = ImageFetcher(Self.cache, session: session, maxConcurrent: Constants.maxConcurrent)
+
+            let exp = expectation(description: "Finished")
+            Task {
+                for iteration in 0 ..< Constants.batchCount {
+                    try await withThrowingTaskGroup(of: ImageResult.self) { group in
+                        for request in 0 ..< Constants.requestCount {
+                            group.addTask {
+                                async let image = fetcher.load(Self.makeURL(iteration * Constants.requestCount + request))
+                                return await image
+                            }
+                        }
+                        try await group.waitForAll()
+                    }
+                    if iteration == Constants.batchCount - 1 {
+                        await MainActor.run {
+                            stopMeasuring()
+                        }
+                        exp.fulfill()
+                    }
+                }
             }
 
             wait(for: [exp], timeout: 20.0)

--- a/Tests/ImageFetcherTests/PerformanceTests.swift
+++ b/Tests/ImageFetcherTests/PerformanceTests.swift
@@ -71,7 +71,6 @@ final class PerformanceTests: XCTestCase {
             } catch {
                 XCTFail("DiskCacke.syncDeleteAll() threw error")
             }
-            print("Done")
         }
     }
 
@@ -110,7 +109,6 @@ final class PerformanceTests: XCTestCase {
             } catch {
                 XCTFail("DiskCacke.syncDeleteAll() threw error")
             }
-            print("Done")
         }
     }
 
@@ -147,7 +145,6 @@ final class PerformanceTests: XCTestCase {
             } catch {
                 XCTFail("DiskCacke.syncDeleteAll() threw error")
             }
-            print("Done")
         }
     }
 
@@ -188,7 +185,6 @@ final class PerformanceTests: XCTestCase {
             } catch {
                 XCTFail("DiskCacke.syncDeleteAll() threw error")
             }
-            print("Done")
         }
     }
 }

--- a/Tests/ImageFetcherTests/PerformanceTests.swift
+++ b/Tests/ImageFetcherTests/PerformanceTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+@testable import ImageFetcher
+
+final class ImageFetcherPerformanceTests: XCTestCase {
+    enum Constants {
+        static let iterationCount = 5_000
+        static let imageSide: Int = 250
+        static let baseURLString = "https://example.com"
+        static var imageSize: CGSize {
+            .init(width: Self.imageSide, height: Self.imageSide)
+        }
+    }
+
+    static var cache: DiskCache!
+
+    override class func setUp() {
+        super.setUp()
+        do {
+            cache = try DiskCache(storageType: .temporary(nil))
+        } catch {
+            fatalError()
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        do {
+            try Self.cache.syncDeleteAll()
+        } catch {
+            fatalError()
+        }
+    }
+
+    static func makeURL(_ iteration: Int) -> URL {
+        // Periodically hit the cache
+        if iteration % 7 == 0 {
+            return URL(string: Constants.baseURLString)!
+        }
+
+        return URL(string: "\(Constants.baseURLString)/\(iteration)")!
+    }
+
+    func testSyncPerformance() throws {
+        let session = URLSession(configuration: .mock)
+        URLProtocolMock.responseProvider = { url in
+            .success((Color.random().image(Constants.imageSize).pngData()!, Mock.makeResponse(url: url)))
+        }
+
+        measure {
+            let fetcher = ImageFetcher(Self.cache, session: session)
+
+            var responseCount = 0
+            let exp = expectation(description: "Finished")
+            for iteration in 0 ..< Constants.iterationCount {
+                fetcher.load(Self.makeURL(iteration)) { _ in
+                    responseCount += 1
+
+                    if responseCount == Constants.iterationCount {
+                        exp.fulfill()
+                    }
+                }
+            }
+
+            wait(for: [exp], timeout: 20.0)
+            do {
+                try Self.cache.syncDeleteAll()
+            } catch {
+                XCTFail()
+            }
+            print("Done")
+        }
+    }
+
+    func testAsyncPerformance() async throws {
+        let session = URLSession(configuration: .mock)
+        URLProtocolMock.responseProvider = { url in
+            .success((Color.random().image(Constants.imageSize).pngData()!, Mock.makeResponse(url: url)))
+        }
+
+        measureMetrics([.wallClockTime], automaticallyStartMeasuring: true) {
+            let fetcher = ImageFetcher(Self.cache, session: session)
+
+            let exp = expectation(description: "Finished")
+            Task {
+                await withThrowingTaskGroup(of: ImageResult.self) { group in
+                    for iteration in 0 ..< Constants.iterationCount {
+                        group.addTask {
+                            async let image = fetcher.load(Self.makeURL(iteration))
+                            return await image
+                        }
+                    }
+                }
+
+                await MainActor.run {
+                    stopMeasuring()
+                }
+                exp.fulfill()
+            }
+
+            wait(for: [exp], timeout: 20.0)
+            do {
+                try Self.cache.syncDeleteAll()
+            } catch {
+                XCTFail()
+            }
+            print("Done")
+        }
+    }
+}

--- a/Tests/ImageFetcherTests/PerformanceTests.swift
+++ b/Tests/ImageFetcherTests/PerformanceTests.swift
@@ -42,8 +42,8 @@ final class PerformanceTests: XCTestCase {
 
     func testSyncPerformance() throws {
         let session = URLSession(configuration: .mock)
-        URLProtocolMock.responseProvider = { url in
-            .success((Color.random().image(Constants.imageSize).pngData()!, Mock.makeResponse(url: url)))
+        MockURLProtocol.responseProvider = { url in
+            (Color.random().image(Constants.imageSize).pngData()!, Mock.makeResponse(url: url))
         }
 
         measure {
@@ -73,8 +73,8 @@ final class PerformanceTests: XCTestCase {
 
     func testAsyncPerformance() async throws {
         let session = URLSession(configuration: .mock)
-        URLProtocolMock.responseProvider = { url in
-            .success((Color.random().image(Constants.imageSize).pngData()!, Mock.makeResponse(url: url)))
+        MockURLProtocol.responseProvider = { url in
+            (Color.random().image(Constants.imageSize).pngData()!, Mock.makeResponse(url: url))
         }
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: true) {


### PR DESCRIPTION
Successive calls to `ImageFetcher.load(_:)` can cause a `EXC_BAD_ACCESS` exception when inserting an `ImageFetcherTask` into `.tasks`. This fix initializes a new `DispatchQueue` for `workerQueue` rather than using `DispatchQueue.global()`.

Also:

- initialize `ImageFetcher` with an instance conforming to `Session` which is used when creating `DataOperation`
- adds performance tests for the synchronous and asynchronous versions of `ImageFetcher.load(_:)`. These tests are where I encountered the crash. Their motivation is to provide a baseline against which to evaluate a pure async implementation.

Questions: 

- should we unignore `.swiftpm/xcode/xcshareddata/xcbaselines/*`?
- there probably isn't any point in running the performance tests as part of the `Swift Test` GitHub action unless we add benchmarks for the CI. We could modify the `Run tests` step to append a `-filter` arg or add a test plan and use `xcodebuild test -testPlan ...` (though I really don't see much need for test plans here)