### PR TITLE
Remove Completed Tasks

### DIFF
--- a/Sources/ImageFetcher/ImageFetcher.swift
+++ b/Sources/ImageFetcher/ImageFetcher.swift
@@ -300,6 +300,11 @@ private extension ImageFetcher {
 
             // call the handle with an image result
             task.result = imageResult
+
+            // remove fetcher task from tasks
+            sself.workerQueue.sync {
+                _ = sself.tasks.remove(task)
+            }
         }
     }
 }

--- a/Sources/ImageFetcher/ImageFetcher.swift
+++ b/Sources/ImageFetcher/ImageFetcher.swift
@@ -309,3 +309,9 @@ private extension ImageFetcher {
     }
 }
 
+// MARK: - Internal Test Members
+internal extension ImageFetcher {
+    var taskCount: Int {
+        tasks.count
+    }
+}

--- a/Tests/ImageFetcherTests/Helpers.swift
+++ b/Tests/ImageFetcherTests/Helpers.swift
@@ -43,6 +43,8 @@ extension Color {
 }
 
 enum Mock {
+    static var baseURL = URL(string: "https://example.com")!
+
     static func makeResponse(url: URL, statusCode: Int = 200, headerFields: [String: String]? = nil) -> HTTPURLResponse {
         HTTPURLResponse(
             url: url,

--- a/Tests/ImageFetcherTests/ImageFetcherTests.swift
+++ b/Tests/ImageFetcherTests/ImageFetcherTests.swift
@@ -1,4 +1,42 @@
 import XCTest
 @testable import ImageFetcher
 
-final class ImageFetcherTests: XCTestCase {}
+final class ImageFetcherTests: XCTestCase {
+    static var cache: DiskCache!
+
+    override class func setUp() {
+        super.setUp()
+        do {
+            cache = try DiskCache(storageType: .temporary(nil))
+        } catch {
+            fatalError()
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        do {
+            try Self.cache.syncDeleteAll()
+        } catch {
+            fatalError()
+        }
+    }
+
+    func testCompletedTaskRemoval() throws {
+        let session = URLSession(configuration: .mock)
+        MockURLProtocol.responseProvider = { url in
+            (Data(), Mock.makeResponse(url: url))
+        }
+        let fetcher = ImageFetcher(Self.cache, session: session)
+
+        let exp = expectation(description: "Finished")
+        fetcher.load(Mock.baseURL) { _ in
+            exp.fulfill()
+        }
+        wait(for: [exp], timeout: 1.0)
+
+        let expected = 0
+        let actual = fetcher.taskCount
+        XCTAssertEqual(expected, actual)
+    }
+}

--- a/Tests/ImageFetcherTests/PerformanceTests.swift
+++ b/Tests/ImageFetcherTests/PerformanceTests.swift
@@ -71,7 +71,6 @@ final class PerformanceTests: XCTestCase {
             } catch {
                 XCTFail()
             }
-            print("Done")
         }
     }
 
@@ -110,7 +109,6 @@ final class PerformanceTests: XCTestCase {
             } catch {
                 XCTFail()
             }
-            print("Done")
         }
     }
 
@@ -147,7 +145,6 @@ final class PerformanceTests: XCTestCase {
             } catch {
                 XCTFail()
             }
-            print("Done")
         }
     }
 
@@ -188,7 +185,6 @@ final class PerformanceTests: XCTestCase {
             } catch {
                 XCTFail()
             }
-            print("Done")
         }
     }
 }


### PR DESCRIPTION
`ImageFetcherTasks` were not being removed from `.tasks`upon completion. This fixes that.