### PR TITLE
Add async Methods to Protocols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
-.swiftpm/xcode/package.xcworkspace
+.swiftpm/xcode/package.xcworkspace/xcuserdata
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 Package.resolved

--- a/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
+++ b/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>FILEHEADER</key>
+	<string>
+//  ___FILENAME___
+//  Mobelux
+//
+//  MIT License
+//
+//  Copyright (c) ___YEAR___ Mobelux LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//</string>
+</dict>
+</plist>

--- a/Sources/ImageFetcher/ImageFetcher.swift
+++ b/Sources/ImageFetcher/ImageFetcher.swift
@@ -187,10 +187,16 @@ public extension ImageFetcher {
         tasks.remove(task)
     }
 
+    /// Returns the `ImageLoaderTask` associated with the given url, if one exists
+    /// - Parameter url: The url of the image to be downloaded.
+    /// - Returns: An instance of `ImageLoaderTask`. Be sure to check `result` before adding a handler.
     subscript (_ url: URL) -> ImageFetcherTask? {
         self[ImageConfiguration(url: url)]
     }
 
+    /// Returns the `ImageLoaderTask` associated with the given configuration, if one exists
+    /// - Parameter url: The configuration of the image to be downloaded.
+    /// - Returns: An instance of `ImageLoaderTask`. Be sure to check `result` before adding a handler.
     subscript (_ imageConfiguration: ImageConfiguration) -> ImageFetcherTask? {
         tasks.first(where: { (task) -> Bool in
             task.configuration == imageConfiguration

--- a/Sources/ImageFetcher/ImageFetcher.swift
+++ b/Sources/ImageFetcher/ImageFetcher.swift
@@ -209,7 +209,7 @@ public extension ImageFetcher {
     }
 
     /// Deletes image from the cache
-    /// - Parameter imageConfiguration: The url of the image to be deleted.
+    /// - Parameter url: The url of the image to be deleted.
     func delete(_ url: URL) throws {
         try delete(ImageConfiguration(url: url))
     }

--- a/Sources/ImageFetcher/Protocols/ImageFetching.swift
+++ b/Sources/ImageFetcher/Protocols/ImageFetching.swift
@@ -52,6 +52,9 @@ public protocol ImageURLFetching {
     /// Deletes all images in the cache
     func deleteCache() throws
 
+    /// Returns the `ImageLoaderTask` associated with the given url, if one exists
+    /// - Parameter url: The url of the image to be downloaded.
+    /// - Returns: An instance of `ImageLoaderTask`. Be sure to check `result` before adding a handler.
     subscript (_ url: URL) -> ImageFetcherTask? { get }
 }
 
@@ -95,6 +98,9 @@ public protocol ImageConfigurationFetching {
     /// Deletes all images in the cache
     func deleteCache() throws
 
+    /// Returns the `ImageLoaderTask` associated with the given configuration, if one exists
+    /// - Parameter url: The configuration of the image to be downloaded.
+    /// - Returns: An instance of `ImageLoaderTask`. Be sure to check `result` before adding a handler.
     subscript (_ imageConfiguration: ImageConfiguration) -> ImageFetcherTask? { get }
 }
 

--- a/Sources/ImageFetcher/Protocols/ImageFetching.swift
+++ b/Sources/ImageFetcher/Protocols/ImageFetching.swift
@@ -46,7 +46,7 @@ public protocol ImageURLFetching {
     func cache(_ image: Image, key: URL) throws
 
     /// Deletes image from the cache
-    /// - Parameter imageConfiguration: The url of the image to be deleted.
+    /// - Parameter url: The url of the image to be deleted.
     func delete(_ url: URL) throws
 
     /// Deletes all images in the cache

--- a/Sources/ImageFetcher/Protocols/ImageFetching.swift
+++ b/Sources/ImageFetcher/Protocols/ImageFetching.swift
@@ -19,21 +19,11 @@ public protocol ImageURLFetching {
     ///   - handler: The handler which passes in an `ImageLoaderTask`. Always call on the main thread.
     func task(_ url: URL, handler: @escaping (ImageFetcherTask) -> ())
 
-    /// Builds a `ImageLoaderTask`. If the result of the image configuration is cached, the task will be returned immediately. Otherwise a download operation will be kicked off.
-    /// - Parameter url: The url of the image to be downloaded.
-    /// - Returns: An instance of `ImageLoaderTask`. Be sure to check `result` before adding a handler.
-    func task(_ url: URL) async -> ImageFetcherTask
-
     /// Loads the `ImageConfiguration`. If the result of the image configuration is cached, `handler` will be called immediately. Otherwise a download operation will be kicked off.
     /// - Parameters:
     ///   - url: The url of the image to be downloaded.
     ///   - handler: The handler which passes in an `ImageHandler`. Always called on the main thread.
     func load(_ url: URL, handler: ImageHandler?)
-
-    /// Loads the `ImageConfiguration`. If the result of the image configuration is cached, the result will be returned immediately. Otherwise a download operation will be kicked off.
-    /// - Parameter url: The url of the image to be downloaded.
-    /// - Returns: The result of the image load.
-    func load(_ url: URL) async -> ImageResult
 
     /// Cancels an in-flight image load
     /// - Parameter url: The url of the image to be downloaded.
@@ -56,6 +46,18 @@ public protocol ImageURLFetching {
     /// - Parameter url: The url of the image to be downloaded.
     /// - Returns: An instance of `ImageLoaderTask`. Be sure to check `result` before adding a handler.
     subscript (_ url: URL) -> ImageFetcherTask? { get }
+
+    // Async support
+
+    /// Builds a `ImageLoaderTask`. If the result of the image configuration is cached, the task will be returned immediately. Otherwise a download operation will be kicked off.
+    /// - Parameter url: The url of the image to be downloaded.
+    /// - Returns: An instance of `ImageLoaderTask`. Be sure to check `result` before adding a handler.
+    func task(_ url: URL) async -> ImageFetcherTask
+
+    /// Loads the `ImageConfiguration`. If the result of the image configuration is cached, the result will be returned immediately. Otherwise a download operation will be kicked off.
+    /// - Parameter url: The url of the image to be downloaded.
+    /// - Returns: The result of the image load.
+    func load(_ url: URL) async -> ImageResult
 }
 
 public protocol ImageConfigurationFetching {
@@ -65,21 +67,11 @@ public protocol ImageConfigurationFetching {
     ///   - handler: The handler which passes in an `ImageLoaderTask`. Always call on the main thread.
     func task(_ imageConfiguration: ImageConfiguration, handler: @escaping (ImageFetcherTask) -> ())
 
-    /// Builds a `ImageLoaderTask`. If the result of the image configuration is cached, the task will be returned immediately. Otherwise a download operation will be kicked off.
-    /// - Parameter imageConfiguration: The configuation of the image to be downloaded.
-    /// - Returns: An instance of `ImageLoaderTask`. Be sure to check `result` before adding a handler.
-    func task(_ imageConfiguration: ImageConfiguration) async -> ImageFetcherTask
-
     /// Loads the `ImageConfiguration`. If the result of the image configuration is cached, `handler` will be called immediately. Otherwise a download operation will be kicked off.
     /// - Parameters:
     ///   - imageConfiguration: The configuation of the image to be downloaded.
     ///   - handler: The handler which passes in an `ImageHandler`. Always called on the main thread.
     func load(_ imageConfiguration: ImageConfiguration, handler: ImageHandler?)
-
-    /// Loads the `ImageConfiguration`. If the result of the image configuration is cached, the result will be returned immediately. Otherwise a download operation will be kicked off.
-    /// - Parameter imageConfiguration: The configuation of the image to be downloaded.
-    /// - Returns: The result of the image load.
-    func load(_ imageConfiguration: ImageConfiguration) async -> ImageResult
 
     /// Cancels an in-flight image load
     /// - Parameter imageConfiguration: The configuation of the image to be downloaded.
@@ -102,6 +94,18 @@ public protocol ImageConfigurationFetching {
     /// - Parameter url: The configuration of the image to be downloaded.
     /// - Returns: An instance of `ImageLoaderTask`. Be sure to check `result` before adding a handler.
     subscript (_ imageConfiguration: ImageConfiguration) -> ImageFetcherTask? { get }
+
+    // Async support
+
+    /// Builds a `ImageLoaderTask`. If the result of the image configuration is cached, the task will be returned immediately. Otherwise a download operation will be kicked off.
+    /// - Parameter imageConfiguration: The configuation of the image to be downloaded.
+    /// - Returns: An instance of `ImageLoaderTask`. Be sure to check `result` before adding a handler.
+    func task(_ imageConfiguration: ImageConfiguration) async -> ImageFetcherTask
+
+    /// Loads the `ImageConfiguration`. If the result of the image configuration is cached, the result will be returned immediately. Otherwise a download operation will be kicked off.
+    /// - Parameter imageConfiguration: The configuation of the image to be downloaded.
+    /// - Returns: The result of the image load.
+    func load(_ imageConfiguration: ImageConfiguration) async -> ImageResult
 }
 
 public protocol ImageFetching: ImageURLFetching & ImageConfigurationFetching {}

--- a/Sources/ImageFetcher/Protocols/ImageFetching.swift
+++ b/Sources/ImageFetcher/Protocols/ImageFetching.swift
@@ -13,26 +13,86 @@ import UIKit
 #endif
 
 public protocol ImageURLFetching {
+    /// Builds a `ImageLoaderTask`. If the result of the image configuration is cached, `handler` will be called immediately. Otherwise a download operation will be kicked off
+    /// - Parameters:
+    ///   - url: The url of the image to be downloaded.
+    ///   - handler: The handler which passes in an `ImageLoaderTask`. Always call on the main thread.
     func task(_ url: URL, handler: @escaping (ImageFetcherTask) -> ())
+
+    /// Builds a `ImageLoaderTask`. If the result of the image configuration is cached, the task will be returned immediately. Otherwise a download operation will be kicked off.
+    /// - Parameter url: The url of the image to be downloaded.
+    /// - Returns: An instance of `ImageLoaderTask`. Be sure to check `result` before adding a handler.
     func task(_ url: URL) async -> ImageFetcherTask
+
+    /// Loads the `ImageConfiguration`. If the result of the image configuration is cached, `handler` will be called immediately. Otherwise a download operation will be kicked off.
+    /// - Parameters:
+    ///   - url: The url of the image to be downloaded.
+    ///   - handler: The handler which passes in an `ImageHandler`. Always called on the main thread.
     func load(_ url: URL, handler: ImageHandler?)
+
+    /// Loads the `ImageConfiguration`. If the result of the image configuration is cached, the result will be returned immediately. Otherwise a download operation will be kicked off.
+    /// - Parameter url: The url of the image to be downloaded.
+    /// - Returns: The result of the image load.
     func load(_ url: URL) async -> ImageResult
+
+    /// Cancels an in-flight image load
+    /// - Parameter url: The url of the image to be downloaded.
     func cancel(_ url: URL)
+
+    /// Saves in image to the cache
+    /// - Parameters:
+    ///   - image: The image instance
+    ///   - key: The url of the image to be saved.
     func cache(_ image: Image, key: URL) throws
+
+    /// Deletes image from the cache
+    /// - Parameter imageConfiguration: The url of the image to be deleted.
     func delete(_ url: URL) throws
+
+    /// Deletes all images in the cache
     func deleteCache() throws
 
     subscript (_ url: URL) -> ImageFetcherTask? { get }
 }
 
 public protocol ImageConfigurationFetching {
+    /// Builds a `ImageLoaderTask`. If the result of the image configuration is cached, `handler` will be called immediately. Otherwise a download operation will be kicked off
+    /// - Parameters:
+    ///   - imageConfiguration: The configuation of the image to be downloaded.
+    ///   - handler: The handler which passes in an `ImageLoaderTask`. Always call on the main thread.
     func task(_ imageConfiguration: ImageConfiguration, handler: @escaping (ImageFetcherTask) -> ())
+
+    /// Builds a `ImageLoaderTask`. If the result of the image configuration is cached, the task will be returned immediately. Otherwise a download operation will be kicked off.
+    /// - Parameter imageConfiguration: The configuation of the image to be downloaded.
+    /// - Returns: An instance of `ImageLoaderTask`. Be sure to check `result` before adding a handler.
     func task(_ imageConfiguration: ImageConfiguration) async -> ImageFetcherTask
+
+    /// Loads the `ImageConfiguration`. If the result of the image configuration is cached, `handler` will be called immediately. Otherwise a download operation will be kicked off.
+    /// - Parameters:
+    ///   - imageConfiguration: The configuation of the image to be downloaded.
+    ///   - handler: The handler which passes in an `ImageHandler`. Always called on the main thread.
     func load(_ imageConfiguration: ImageConfiguration, handler: ImageHandler?)
+
+    /// Loads the `ImageConfiguration`. If the result of the image configuration is cached, the result will be returned immediately. Otherwise a download operation will be kicked off.
+    /// - Parameter imageConfiguration: The configuation of the image to be downloaded.
+    /// - Returns: The result of the image load.
     func load(_ imageConfiguration: ImageConfiguration) async -> ImageResult
+
+    /// Cancels an in-flight image load
+    /// - Parameter imageConfiguration: The configuation of the image to be downloaded.
     func cancel(_ imageConfiguration: ImageConfiguration)
+
+    /// Saves in image to the cache
+    /// - Parameters:
+    ///   - image: The image instance
+    ///   - key: The configuation of the image to be saved.
     func cache(_ image: Image, key: ImageConfiguration) throws
+
+    /// Deletes image from the cache
+    /// - Parameter imageConfiguration: The configuation of the image to be deleted.
     func delete(_ imageConfiguration: ImageConfiguration) throws
+
+    /// Deletes all images in the cache
     func deleteCache() throws
 
     subscript (_ imageConfiguration: ImageConfiguration) -> ImageFetcherTask? { get }

--- a/Sources/ImageFetcher/Protocols/ImageFetching.swift
+++ b/Sources/ImageFetcher/Protocols/ImageFetching.swift
@@ -14,7 +14,9 @@ import UIKit
 
 public protocol ImageURLFetching {
     func task(_ url: URL, handler: @escaping (ImageFetcherTask) -> ())
+    func task(_ url: URL) async -> ImageFetcherTask
     func load(_ url: URL, handler: ImageHandler?)
+    func load(_ url: URL) async -> ImageResult
     func cancel(_ url: URL)
     func cache(_ image: Image, key: URL) throws
     func delete(_ url: URL) throws
@@ -25,7 +27,9 @@ public protocol ImageURLFetching {
 
 public protocol ImageConfigurationFetching {
     func task(_ imageConfiguration: ImageConfiguration, handler: @escaping (ImageFetcherTask) -> ())
+    func task(_ imageConfiguration: ImageConfiguration) async -> ImageFetcherTask
     func load(_ imageConfiguration: ImageConfiguration, handler: ImageHandler?)
+    func load(_ imageConfiguration: ImageConfiguration) async -> ImageResult
     func cancel(_ imageConfiguration: ImageConfiguration)
     func cache(_ image: Image, key: ImageConfiguration) throws
     func delete(_ imageConfiguration: ImageConfiguration) throws


### PR DESCRIPTION
Adds async methods to the `ImageURLFetching` and `ImageConfigurationFetching` protocols. I also added documentation to the protocol members and the subscripts.

Finally, I added a file header template macro matching the format used for the other files.