### PR TITLE
Crash From Subscript Access

### DIFF
--- a/Tests/ImageFetcherTests/Helpers.swift
+++ b/Tests/ImageFetcherTests/Helpers.swift
@@ -52,6 +52,15 @@ enum Mock {
             httpVersion: "HTTP/1.1",
             headerFields: headerFields)!
     }
+
+    static func makeURL(_ iteration: Int) -> URL {
+        // Periodically hit the cache
+        if iteration % 7 == 0 {
+            return baseURL
+        }
+
+        return baseURL.appendingPathComponent("\(iteration)")
+    }
 }
 
 final class MockURLProtocol: URLProtocol {

--- a/Tests/ImageFetcherTests/ImageFetcherTests.swift
+++ b/Tests/ImageFetcherTests/ImageFetcherTests.swift
@@ -39,4 +39,43 @@ final class ImageFetcherTests: XCTestCase {
         let actual = fetcher.taskCount
         XCTAssertEqual(expected, actual)
     }
+
+    func testSubscriptAccess() async throws {
+        let requestCount: Int = 100
+
+        // Config
+        let session = URLSession(configuration: .mock)
+        MockURLProtocol.responseDelay = 0.1
+        MockURLProtocol.responseProvider = { url in
+            (Color.random().image(CGSize(width: 100, height: 100)).pngData()!, Mock.makeResponse(url: url))
+        }
+
+        let sut = ImageFetcher(Self.cache, session: session, maxConcurrent: 4)
+
+        async let images = await withThrowingTaskGroup(of: Image.self, returning: [Image].self) { taskGroup in
+            for iteration in 0 ..< requestCount {
+                let url = Mock.makeURL(iteration)
+
+                taskGroup.addTask {
+                    try await sut.load(url).get().value
+                }
+            }
+
+            return try await taskGroup.reduce(into: [Image]()) { images, image in
+                    images.append(image)
+            }
+        }
+
+        async let subscriptAccess: Void = await withTaskGroup(of: Void.self) { taskGroup in
+            for iteration in 0 ..< 1_000_000 {
+                let url = Mock.makeURL(iteration)
+
+                taskGroup.addTask {
+                    _ = sut[url]
+                }
+            }
+        }
+
+        _ = try await (images, subscriptAccess)
+    }
 }

--- a/Tests/ImageFetcherTests/PerformanceTests.swift
+++ b/Tests/ImageFetcherTests/PerformanceTests.swift
@@ -3,7 +3,6 @@ import XCTest
 
 final class PerformanceTests: XCTestCase {
     enum Constants {
-        static let baseURLString = "https://example.com"
         static let iterationCount = 500
         static let batchCount = 5
         static let requestCount = 10
@@ -35,15 +34,6 @@ final class PerformanceTests: XCTestCase {
         }
     }
 
-    static func makeURL(_ iteration: Int) -> URL {
-        // Periodically hit the cache
-        if iteration % 7 == 0 {
-            return URL(string: Constants.baseURLString)!
-        }
-
-        return URL(string: "\(Constants.baseURLString)/\(iteration)")!
-    }
-
     func testSyncPerformance() throws {
         let session = URLSession(configuration: .mock)
         MockURLProtocol.responseProvider = { url in
@@ -56,7 +46,7 @@ final class PerformanceTests: XCTestCase {
             var responseCount = 0
             let exp = expectation(description: "Finished")
             for iteration in 0 ..< Constants.iterationCount {
-                fetcher.load(Self.makeURL(iteration)) { _ in
+                fetcher.load(Mock.makeURL(iteration)) { _ in
                     responseCount += 1
 
                     if responseCount == Constants.iterationCount {
@@ -89,7 +79,7 @@ final class PerformanceTests: XCTestCase {
                 var responseCount = 0
                 let innerExp = expectation(description: "Finished Iteration Requests")
                 for request in 0 ..< Constants.requestCount {
-                    fetcher.load(Self.makeURL(iteration * Constants.requestCount + request)) { _ in
+                    fetcher.load(Mock.makeURL(iteration * Constants.requestCount + request)) { _ in
                         responseCount += 1
                         if responseCount == Constants.requestCount {
                             innerExp.fulfill()
@@ -126,7 +116,7 @@ final class PerformanceTests: XCTestCase {
                 try await withThrowingTaskGroup(of: ImageResult.self) { group in
                     for iteration in 0 ..< Constants.iterationCount {
                         group.addTask {
-                            async let image = fetcher.load(Self.makeURL(iteration))
+                            async let image = fetcher.load(Mock.makeURL(iteration))
                             return await image
                         }
                     }
@@ -164,7 +154,7 @@ final class PerformanceTests: XCTestCase {
                     try await withThrowingTaskGroup(of: ImageResult.self) { group in
                         for request in 0 ..< Constants.requestCount {
                             group.addTask {
-                                async let image = fetcher.load(Self.makeURL(iteration * Constants.requestCount + request))
+                                async let image = fetcher.load(Mock.makeURL(iteration * Constants.requestCount + request))
                                 return await image
                             }
                         }


### PR DESCRIPTION
Subscript access was not thread-safe, leading to potential crashes when using `subscript(_:)` from one thread while the worker queue was writing to it.

This adds an `NSLock` and a series of methods to insert, read, and remove `ImageFetcherTask`s from `ImageFetcher.tasks`. These methods use that lock when accessing `tasks`. Given that these should be fairly quick -- I don't expect `n` to realistically be large enough that the worst-case O(_n_)  performance of `getTask(_:)` should matter -- I opted to use `NSLock` rather than incur the potential cost of thread-hopping to use `workerQueue` to protect `tasks`.

I opted to add a `getTask(_:)` method in addition to the existing subscript methods so that all internal access to `tasks` happens through similar thread-safe methods (`subscript(_:)` simply calls `getTask(_:)` now).