### PR TITLE
Fix Leaked Continuations

### DIFF
--- a/Sources/ImageFetcher/ImageError.swift
+++ b/Sources/ImageFetcher/ImageError.swift
@@ -29,7 +29,6 @@ import Foundation
 import DataOperation
 
 public enum ImageError: LocalizedError {
-    case cancelled
     case cannotParse
     case noResult
     case unknown
@@ -37,7 +36,6 @@ public enum ImageError: LocalizedError {
 
     public var errorDescription: String {
         switch self {
-        case .cancelled: return NSLocalizedString("ImageLoader.cancelled", comment: "")
         case .cannotParse: return NSLocalizedString("ImageLoader.cannotParse", comment: "")
         case .noResult: return NSLocalizedString("ImageLoader.noResult", comment: "")
         case .unknown: return NSLocalizedString("Generic.unknownError", comment: "")

--- a/Sources/ImageFetcher/ImageError.swift
+++ b/Sources/ImageFetcher/ImageError.swift
@@ -29,6 +29,7 @@ import Foundation
 import DataOperation
 
 public enum ImageError: LocalizedError {
+    case cancelled
     case cannotParse
     case noResult
     case unknown
@@ -36,6 +37,7 @@ public enum ImageError: LocalizedError {
 
     public var errorDescription: String {
         switch self {
+        case .cancelled: return NSLocalizedString("ImageLoader.cancelled", comment: "")
         case .cannotParse: return NSLocalizedString("ImageLoader.cannotParse", comment: "")
         case .noResult: return NSLocalizedString("ImageLoader.noResult", comment: "")
         case .unknown: return NSLocalizedString("Generic.unknownError", comment: "")

--- a/Sources/ImageFetcher/ImageFetcher.swift
+++ b/Sources/ImageFetcher/ImageFetcher.swift
@@ -180,7 +180,7 @@ public extension ImageFetcher {
             return
         }
 
-        task.result = .failure(.cancelled)
+        task.result = .failure(.noResult)
         task.cancel()
         task.operation = nil
         task.handler = nil

--- a/Sources/ImageFetcher/ImageFetcher.swift
+++ b/Sources/ImageFetcher/ImageFetcher.swift
@@ -180,6 +180,7 @@ public extension ImageFetcher {
             return
         }
 
+        task.result = .failure(.cancelled)
         task.cancel()
         task.operation = nil
         task.handler = nil

--- a/Sources/ImageFetcher/ImageFetcher.swift
+++ b/Sources/ImageFetcher/ImageFetcher.swift
@@ -181,9 +181,9 @@ public extension ImageFetcher {
         }
 
         task.result = .failure(.noResult)
+        task.handler = nil
         task.cancel()
         task.operation = nil
-        task.handler = nil
 
         tasks.remove(task)
     }

--- a/Tests/ImageFetcherTests/Helpers.swift
+++ b/Tests/ImageFetcherTests/Helpers.swift
@@ -99,3 +99,67 @@ extension URLSessionConfiguration {
         return config
     }
 }
+
+class MockCache: Cache {
+    struct CacheError: Error {
+        let reason: String
+    }
+
+    var onCache: (Data, String) throws -> ()
+    var onData: (String) throws -> Data
+    var onDelete: (String) throws -> ()
+    var onDeleteAll: () throws -> ()
+    var onFileURL: (String) -> URL
+
+    init(
+        onCache: @escaping (Data, String) throws -> () = { _, _ in },
+        onData: @escaping (String) throws -> Data = { _ in Data() },
+        onDelete: @escaping (String) throws -> () = { _ in },
+        onDeleteAll: @escaping () throws -> () = { },
+        onFileURL: @escaping (String) -> URL = { _ in URL(fileURLWithPath: "") }
+    ) {
+        self.onCache = onCache
+        self.onData = onData
+        self.onDelete = onDelete
+        self.onDeleteAll = onDeleteAll
+        self.onFileURL = onFileURL
+    }
+
+    func syncCache(_ data: Data, key: String) throws {
+        try onCache(data, key)
+    }
+
+    func syncData(_ key: String) throws -> Data {
+        try onData(key)
+    }
+
+    func syncDelete(_ key: String) throws {
+        try onDelete(key)
+    }
+
+    func syncDeleteAll() throws {
+        try onDeleteAll()
+    }
+
+    func fileURL(_ key: String) -> URL {
+        onFileURL(key)
+    }
+
+    // Async support
+
+    func cache(_ data: Data, key: String) async throws {
+        try onCache(data, key)
+    }
+
+    func data(_ key: String) async throws -> Data {
+        try onData(key)
+    }
+
+    func delete(_ key: String) async throws {
+        try onDelete(key)
+    }
+
+    func deleteAll() async throws {
+        try onDeleteAll()
+    }
+}

--- a/Tests/ImageFetcherTests/ImageFetcherTests.swift
+++ b/Tests/ImageFetcherTests/ImageFetcherTests.swift
@@ -39,4 +39,29 @@ final class ImageFetcherTests: XCTestCase {
         let actual = fetcher.taskCount
         XCTAssertEqual(expected, actual)
     }
+
+    func testContinuationsAreNotLeaked() async throws {
+        let session = URLSession(configuration: .mock)
+        MockURLProtocol.responseDelay = 5.0
+        MockURLProtocol.responseProvider = { url in
+            (Color.random().image(CGSize(width: 100, height: 100)).pngData()!, Mock.makeResponse(url: url))
+        }
+
+        let cache = MockCache(onData: { _ in throw MockCache.CacheError(reason: "File missing") })
+        let sut = ImageFetcher(cache, session: session)
+
+        let url = URL(string: "https://example.com")!
+        async let result = await sut.load(url)
+
+        try await Task.sleep(nanoseconds: NSEC_PER_SEC)
+        sut.cancel(url)
+
+        let awaitedResult = await result
+        switch awaitedResult {
+        case .failure(.noResult):
+            return
+        default:
+            XCTFail("Result \(awaitedResult) was not a cancellation error")
+        }
+    }
 }


### PR DESCRIPTION
Fixes a bug where cancelling a task created via `ImageFetcher.load(_:)` leaks the continuation when that task fetches a remote image.

`ImageFetcher.cancel(_:)` cancels the `ImageFetcherTask`'s operation and then sets its `handler` -- which is responsible for resuming the continuation from the async version of `load(:)` -- to `nil`. In my testing, the handler is removed before the operation's completion block has the opportunity to call it by setting the task's `result` as this typically happens on a secondary thread. 

To ensure that the `handler` is called (and the continuation resumed), I set the task's `result` and remove its handler before cancelling the operation.

I also added a `MockCache` to simplify testing