### PR TITLE
Networking Refinements

### DIFF
--- a/Sources/ImageFetcher/Extensions/Error+Utils.swift
+++ b/Sources/ImageFetcher/Extensions/Error+Utils.swift
@@ -1,0 +1,44 @@
+//
+//  Error+Utils.swift
+//  Mobelux
+//
+//  MIT License
+//
+//  Copyright (c) 2023 Mobelux LLC
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+public extension Error {
+    /// A Boolean value indicating whether an error was the result of a cancelled task.
+    var wasCancelled: Bool {
+        switch self {
+        case is CancellationError:
+            return true
+        case URLError.cancelled:
+            return true
+        case let imageError as ImageError where imageError.wasCancelled:
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/ImageFetcher/Extensions/Image+Utils.swift
+++ b/Sources/ImageFetcher/Extensions/Image+Utils.swift
@@ -30,7 +30,7 @@ import AppKit
 
 extension NSImage {
     var cgImage: CGImage? {
-        var rect = CGRect.init(origin: .zero, size: size)
+        var rect = CGRect(origin: .zero, size: size)
         return cgImage(forProposedRect: &rect, context: nil, hints: nil)
     }
 

--- a/Sources/ImageFetcher/Extensions/URLSession+Utils.swift
+++ b/Sources/ImageFetcher/Extensions/URLSession+Utils.swift
@@ -54,8 +54,6 @@ public extension URLSession {
     func legacyData(for request: URLRequest) async throws -> (Data, URLResponse) {
         let wrappedTask = WrappedTask()
         return try await withTaskCancellationHandler {
-            wrappedTask.task?.cancel()
-        } operation: {
             try await withUnsafeThrowingContinuation { continuation in
                 wrappedTask.task = dataTask(with: request) { data, response, error in
                     if let error = error {
@@ -68,6 +66,8 @@ public extension URLSession {
                 }
                 wrappedTask.task?.resume()
             }
+        } onCancel: {
+            wrappedTask.task?.cancel()
         }
     }
 }

--- a/Sources/ImageFetcher/ImageError.swift
+++ b/Sources/ImageFetcher/ImageError.swift
@@ -27,13 +27,20 @@
 
 import Foundation
 
+/// An error that occurs while fetching an image.
 public enum ImageError: LocalizedError {
+    /// An indication that an image fetching task was cancelled.
     case cancelled
+    /// An indication that the image data could not be parsed.
     case cannotParse
+    /// An indication that an operation lacked a result.
     case noResult
+    /// An indication that an unknown error occurred.
     case unknown
+    /// An indication that an error with a custom message occurred.
     case custom(String)
 
+    /// A localized message describing what error occurred.
     public var errorDescription: String {
         switch self {
         case .cancelled: return NSLocalizedString("ImageLoader.cancelled", comment: "")

--- a/Sources/ImageFetcher/ImageError.swift
+++ b/Sources/ImageFetcher/ImageError.swift
@@ -40,6 +40,14 @@ public enum ImageError: LocalizedError {
     /// An indication that an error with a custom message occurred.
     case custom(String)
 
+    /// A Boolean value indicating whether an error was the result of a cancelled task.
+    public var wasCancelled: Bool {
+        switch self {
+        case .cancelled: return true
+        default: return false
+        }
+    }
+
     /// A localized message describing what error occurred.
     public var errorDescription: String {
         switch self {

--- a/Sources/ImageFetcher/ImageFetcher.swift
+++ b/Sources/ImageFetcher/ImageFetcher.swift
@@ -203,7 +203,7 @@ public extension ImageFetcher {
 private extension ImageFetcher {
     func download(_ imageConfiguration: ImageConfiguration) async throws -> ImageSource {
         do {
-            let (data, _) = try await networking.load(URLRequest(url: imageConfiguration.url))
+            let data = try await networking.load(URLRequest(url: imageConfiguration.url))
             let image = try await imageProcessor.process(data, configuration: imageConfiguration)
             removeTask(imageConfiguration)
 

--- a/Sources/ImageFetcher/Networking.swift
+++ b/Sources/ImageFetcher/Networking.swift
@@ -60,7 +60,7 @@ public extension Networking {
     ///   - configuration: A configuration object that specifies certain behaviors, such as caching policies, timeouts, proxies, pipelining, TLS versions to support, cookie policies, credential storage, and so on.
     ///   - validateResponse: A closure that throws an error if the response passed to it was not successful.
     init(
-        _ configuration: URLSessionConfiguration = .cacheless,
+        _ configuration: URLSessionConfiguration = .default,
         validateResponse: @escaping (URLResponse) throws -> Void = ResponseValidator.validate
     ) {
         let session = URLSession(configuration: configuration)

--- a/Sources/ImageFetcher/Networking.swift
+++ b/Sources/ImageFetcher/Networking.swift
@@ -31,6 +31,13 @@ import Foundation
 public struct Networking {
     /// Downloads the contents of a URL based on the specified URL request and delivers the data asynchronously.
     public let load: (URLRequest) async throws -> (Data, URLResponse)
+
+    /// Creates a wrapper to perform async network requests.
+    /// - Parameter load: A closure to load a request.
+    public init(load: @escaping (URLRequest) async throws -> (Data, URLResponse)) {
+        // TODO: validate response and just return Data
+        self.load = load
+    }
 }
 
 public extension Networking {

--- a/Sources/ImageFetcher/Networking.swift
+++ b/Sources/ImageFetcher/Networking.swift
@@ -46,13 +46,10 @@ public extension Networking {
     init(_ configuration: URLSessionConfiguration = .cacheless) {
         let session = URLSession(configuration: configuration)
         if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
-            self.load = { request in
-                try await session.data(for: request)
-            }
+            self.load = session.data(for:)
+
         } else {
-            self.load = { request in
-                try await session.legacyData(for: request)
-            }
+            self.load = session.legacyData(for:)
         }
     }
 }

--- a/Sources/ImageFetcher/Networking.swift
+++ b/Sources/ImageFetcher/Networking.swift
@@ -41,7 +41,10 @@ public struct Networking {
 
 public extension Networking {
 
+    /// A type that validates network responses.
     enum ResponseValidator {
+        /// Throws an error if the given response was not successful.
+        /// - Parameter response: The response to validate.
         public static func validate(_ response: URLResponse) throws {
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw ImageError.cannotParse

--- a/Sources/ImageFetcher/Networking.swift
+++ b/Sources/ImageFetcher/Networking.swift
@@ -35,7 +35,6 @@ public struct Networking {
     /// Creates a wrapper to perform async network requests.
     /// - Parameter load: A closure to load a request.
     public init(load: @escaping (URLRequest) async throws -> Data) {
-        // TODO: validate response and just return Data
         self.load = load
     }
 }

--- a/Tests/ImageFetcherTests/Helpers.swift
+++ b/Tests/ImageFetcherTests/Helpers.swift
@@ -51,14 +51,6 @@ enum Mock {
             .pngData()!
     }
 
-    static func makeResponse(url: URL, statusCode: Int = 200, headerFields: [String: String]? = nil) -> HTTPURLResponse {
-        HTTPURLResponse(
-            url: url,
-            statusCode: statusCode,
-            httpVersion: "HTTP/1.1",
-            headerFields: headerFields)!
-    }
-
     static func makeURL(_ iteration: Int, hitCache: (Int) -> Bool = { $0 % 7 == 0 }) -> URL {
         // Periodically hit the cache
         if hitCache(iteration) {
@@ -72,7 +64,7 @@ enum Mock {
 extension Networking {
     static func mock(
         responseDelay: TimeInterval? = nil,
-        responseProvider: @escaping (URL) throws -> (Data, HTTPURLResponse) = { (Data(), Mock.makeResponse(url: $0)) }
+        responseProvider: @escaping (URL) throws -> Data = { _ in Data() }
     ) -> Self {
         .init(
             load: { request in

--- a/Tests/ImageFetcherTests/Helpers.swift
+++ b/Tests/ImageFetcherTests/Helpers.swift
@@ -51,7 +51,7 @@ enum Mock {
             .pngData()!
     }
 
-    static func makeURL(_ iteration: Int, hitCache: (Int) -> Bool = { $0 % 7 == 0 }) -> URL {
+    static func makeURL(_ iteration: Int = 1, hitCache: (Int) -> Bool = { $0 % 7 == 0 }) -> URL {
         // Periodically hit the cache
         if hitCache(iteration) {
             return baseURL

--- a/Tests/ImageFetcherTests/ImageFetcherTests.swift
+++ b/Tests/ImageFetcherTests/ImageFetcherTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class ImageFetcherTests: XCTestCase {
     func testCompletedTaskRemoval() async throws {
         let cache = MockCache(onData: { _ in throw MockCache.CacheError(reason: "File missing") })
-        let networking = Networking.mock(responseDelay: 0.1) { (Mock.makeImageData(side: 150), Mock.makeResponse(url: $0)) }
+        let networking = Networking.mock(responseDelay: 0.1) { _ in Mock.makeImageData(side: 150) }
         let sut = ImageFetcher(cache, networking: networking, imageProcessor: MockImageProcessor())
 
         let exp = expectation(description: "Finished")
@@ -20,7 +20,7 @@ final class ImageFetcherTests: XCTestCase {
 
     func testContinuationsAreNotLeaked() async throws {
         let cache = MockCache(onData: { _ in throw MockCache.CacheError(reason: "File missing") })
-        let networking = Networking.mock(responseDelay: 1.0) { (Mock.makeImageData(side: 150), Mock.makeResponse(url: $0)) }
+        let networking = Networking.mock(responseDelay: 1.0) { _ in Mock.makeImageData(side: 150) }
         let sut = ImageFetcher(cache, networking: networking, imageProcessor: MockImageProcessor())
 
         let url = URL(string: "https://example.com")!
@@ -45,7 +45,7 @@ final class ImageFetcherTests: XCTestCase {
         let requestCount: Int = 100
 
         let cache = MockCache(onData: { _ in throw MockCache.CacheError(reason: "File missing") })
-        let networking = Networking.mock(responseDelay: 0.1) { (Mock.makeImageData(side: 100), Mock.makeResponse(url: $0)) }
+        let networking = Networking.mock(responseDelay: 0.1) { _ in Mock.makeImageData(side: 100) }
         let sut = ImageFetcher(cache, networking: networking, imageProcessor: MockImageProcessor())
 
         async let images = await withThrowingTaskGroup(of: Image.self, returning: [Image].self) { taskGroup in

--- a/Tests/ImageFetcherTests/PerformanceTests.swift
+++ b/Tests/ImageFetcherTests/PerformanceTests.swift
@@ -28,7 +28,7 @@ final class PerformanceTests: XCTestCase {
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: true) {
             let cache = try! DiskCache(storageType: .temporary(.custom("\(Date().timeIntervalSince1970)")))
-            let networking = Networking.mock() { (Mock.makeImageData(side: Constants.imageSide), Mock.makeResponse(url: $0)) }
+            let networking = Networking.mock() { _ in Mock.makeImageData(side: Constants.imageSide) }
             let fetcher = ImageFetcher(cache, networking: networking, imageProcessor: MockImageProcessor())
 
             let exp = expectation(description: "Finished")
@@ -59,7 +59,7 @@ final class PerformanceTests: XCTestCase {
 
         measureMetrics([.wallClockTime], automaticallyStartMeasuring: true) {
             let cache = try! DiskCache(storageType: .temporary(.custom("\(Date().timeIntervalSince1970)")))
-            let networking = Networking.mock(responseDelay: 0.3) { (Mock.makeImageData(side: Constants.imageSide), Mock.makeResponse(url: $0)) }
+            let networking = Networking.mock(responseDelay: 0.3) { _ in Mock.makeImageData(side: Constants.imageSide) }
             let fetcher = ImageFetcher(cache, networking: networking, imageProcessor: MockImageProcessor())
 
             let exp = expectation(description: "Finished")


### PR DESCRIPTION
Updates signature of `Networking.load` to only return `Data` and adds a type to provide default response validation.

Also:

- adds documentation for `ImageError`
- adds `Error.wasCancelled`
- replaces deprecated `withTaskCancellationHandler` method with newer one
- use `URLSessionConfiguration.default` by default
- remove explicit use of `CGRect.init`