### PR TITLE
Add SPI Manifest and GitHub Configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,25 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options
+changelog:
+  exclude:
+    labels:
+      - ci
+      - ignore-for-release
+    authors:
+      - github-actions
+      - octocat
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - semver/major
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - semver/minor
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - semver/patch
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [ImageFetcher]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "ImageFetcher", targets: ["ImageFetcher"])
     ],
     dependencies: [
-         .package(url: "https://github.com/Mobelux/DiskCache", from: "2.0.0"),
+         .package(url: "https://github.com/Mobelux/DiskCache.git", from: "2.0.0"),
          .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -12,28 +12,25 @@ let package = Package(
         .macOS(.v10_15)
     ],
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "ImageFetcher",
-            targets: ["ImageFetcher"]),
+        .library(name: "ImageFetcher", targets: ["ImageFetcher"])
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
          .package(url: "https://github.com/Mobelux/DiskCache", from: "2.0.0"),
          .package(url: "https://github.com/apple/swift-crypto.git", from: "1.0.0")
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "ImageFetcher",
             dependencies: [
                 "DiskCache",
-                .product(
-                    name: "Crypto",
-                    package: "swift-crypto")]),
+                .product(name: "Crypto", package: "swift-crypto")
+            ]
+        ),
         .testTarget(
             name: "ImageFetcherTests",
-            dependencies: ["ImageFetcher"]),
+            dependencies: [
+                "ImageFetcher"
+            ]
+        )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Add `ImageFetcher` to your `Packages.swift` file:
 .package(url: "https://github.com/Mobelux/ImageFetcher.git", from: "2.0.0"),
 ```
 
+Then, add the product to any targets that need access to the library:
+
+```swift
+.product(name: "ImageFetcher", package: "ImageFetcher")
+```
+
 ## ⚙️ Usage
 
 Intialize `ImageFetcher` with a `Cache`:


### PR DESCRIPTION
Adds:

- SPI Manifest
- GitHub dependabots and release configs

Additional:

- Add installation instructions for specifying product
- Reformat package manifest